### PR TITLE
Modernize Nuget package management

### DIFF
--- a/AffinityPluginLoader/AffinityPluginLoader.csproj
+++ b/AffinityPluginLoader/AffinityPluginLoader.csproj
@@ -52,10 +52,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.4.1\lib\net48\0Harmony.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Serif.Affinity">
       <HintPath>C:\Program Files\Affinity\Affinity\Serif.Affinity.dll</HintPath>
       <Private>False</Private>
@@ -84,10 +80,12 @@
     <Compile Include="UI\PluginsPreferencesPage.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <EmbeddedResource Include="UI\PluginsPreferencesPage.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="UI\PluginsPreferencesPage.xaml" />
+    <PackageReference Include="Lib.Harmony">
+      <Version>2.4.2</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AffinityPluginLoader/packages.config
+++ b/AffinityPluginLoader/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Lib.Harmony" version="2.4.1" targetFramework="net48" />
-</packages>

--- a/WineFix/WineFix.csproj
+++ b/WineFix/WineFix.csproj
@@ -55,10 +55,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.4.1\lib\net48\0Harmony.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -74,14 +70,16 @@
     <Compile Include="WineFixPlugin.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\AffinityPluginLoader\AffinityPluginLoader.csproj">
       <Project>{4d3f318e-543f-4a3f-98ed-21b3f579b77b}</Project>
       <Name>AffinityPluginLoader</Name>
       <Private>False</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Lib.Harmony">
+      <Version>2.4.2</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/WineFix/packages.config
+++ b/WineFix/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Lib.Harmony" version="2.4.1" targetFramework="net48" />
-</packages>


### PR DESCRIPTION
- Migrate from packages.config to PackageReference
  - This fixes dotnet restore under Linux and Wine
- Update Harmony to 2.4.2
