### PR TITLE
Adjust project settings to allow compiling under Wine

### DIFF
--- a/AffinityPluginLoader/AffinityPluginLoader.csproj
+++ b/AffinityPluginLoader/AffinityPluginLoader.csproj
@@ -52,7 +52,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serif.Affinity">
+    <Reference Include="Serif.Affinity" Condition="Exists('C:\Program Files\Affinity\Affinity\Serif.Affinity.dll')">
       <HintPath>C:\Program Files\Affinity\Affinity\Serif.Affinity.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -88,4 +88,5 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\NuGet\17.0\Microsoft.NuGet.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\NuGet\17.0\Microsoft.NuGet.targets')" />
 </Project>

--- a/WineFix/WineFix.csproj
+++ b/WineFix/WineFix.csproj
@@ -82,4 +82,5 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\NuGet\17.0\Microsoft.NuGet.targets" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\NuGet\17.0\Microsoft.NuGet.targets')" />
 </Project>


### PR DESCRIPTION
Some configuration changes are required to allow compiling under Wine
- Add explicit reference to NuGet targets path. This is required to allow MSBuild to find NuGet packages restored to the user home directory.
  - VS normally handles this for you, but msvc-wine always adds these targets under a version subdirectory.
- Make Serif.Affinity reference optional (only needed for Intellisense anyways)
  - Not strictly required but gets rid of an annoying warning

These changes will be used to allow compiling under Wine. A Dockerfile will be provided to set everything up that's necessary to compile on Linux.